### PR TITLE
[Feature for AkeaActions] Short note notation for skills and weapons & single parameter resolution

### DIFF
--- a/AkeaBattlerAfterImage.js
+++ b/AkeaBattlerAfterImage.js
@@ -181,6 +181,16 @@ if (Akea.BattleSystem.VERSION < [1, 1, 0]) throw new Error("This plugin only wor
     const _specificName_Game_Battler_callAkeaActions = Game_Battler.prototype.callAkeaActions
     Game_Battler.prototype.callAkeaActions = function (actionName, parameters, action, targets) {
         _specificName_Game_Battler_callAkeaActions.call(this, ...arguments);
+        if (parameters.indexOf(':') === -1) {
+            switch (actionName) {
+                case "AfterImage":
+                    parameters = `id: ${parameters}`;
+                    break;
+                case "StopAfterImage":
+                    parameters = '';
+                    break;
+            }
+        }
         let regex = /(\w+):\s*([^\s]*)/gm;
         let obj = {};
         let id = false;


### PR DESCRIPTION
Hi,

I wanted to improve quality of life on defining actions for skills and weapons on notes, so i came up with a shorter notation, fully compatible with "xml style" notation used with other plugins.

This notation is JS-like, much shorter and less verbose, I leave a working example here:

```
$akea.AfterImage(1)
$akea.Actions(4)
$akea.StopAfterImage()
$akea.Actions(id: 54)
$akea.Hit(100)
$akea.AniTarget(1)
$akea.Actions(55)
```

Although parameter name can still be specified, if unnamed and single, parameter name will be resolved using the action's default (for example, id, damage, time, etc...). Add-ons to AAKS must be updated to support this behavior, I did this with AfterImage add-on, included in this PR. I think there is room for improvement on code readability for this kind of feature.

Short notation must be enabled via the "Short Note Notation" flag on plugin's parameter list, if it is unset or OFF, will fall back to XML-like notation, so is fully backwards compatible with existing projects.

I attach a regexr screenshot for visualization purposes of regex on short notation:
![image](https://user-images.githubusercontent.com/26845823/99757787-e0ea1980-2ace-11eb-8e39-588cb78d5557.png)

Check it out, I am already working with this change on my project and is working nicely.

Also added a fallback enemy spritesheet for monsters without enemy spritesheet definition.